### PR TITLE
Migrate to NNBD

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,13 +43,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -62,13 +55,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_phosphor_icons:
-    dependency: "direct dev"
-    description:
-      path: ".."
-      relative: true
-    source: path
-    version: "0.0.1+3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1+3
 homepage: https://github.com/afkcodes/flutter_phosphor_icons
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Just needed to upgrade the dart sdk to min 2.12.0 in `the pubspec.yaml`:
```
environment:
  sdk: ">=2.12.0 <3.0.0"
```

Then I run `dart migrate` tool:
```
dart migrate
  ╔════════════════════════════════════════════════════════════════════════════╗
  ║ The Dart tool uses Google Analytics to anonymously report feature usage    ║
  ║ statistics and to send basic crash reports. This data is used to help      ║
  ║ improve the Dart platform and tools over time.                             ║
  ║                                                                            ║
  ║ To disable reporting of anonymous analytics, run:                          ║
  ║                                                                            ║
  ║   dart --disable-analytics                                                 ║
  ║                                                                            ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Migrating /Users/mabe/Documents/flutter_phosphor_icons

See https://dart.dev/go/null-safety-migration for a migration guide.

Note: more than one project found; migrating the top-level project.

Analyzing project...
[-------------\]
All sources appear to be already migrated.  Nothing to do.
```